### PR TITLE
Update symfony/flex to 1.17.2

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -31,7 +31,7 @@
         "symfony/dotenv": "5.2.4",
         "symfony/expression-language": "5.2.7",
         "symfony/finder": "5.2.9",
-        "symfony/flex": "1.13.3",
+        "symfony/flex": "1.17.2",
         "symfony/framework-bundle": "4.4.24",
         "symfony/http-client": "5.2.9",
         "symfony/mailer": "5.2.7",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3202b653da5c10ea294128f99decb8e9",
+    "content-hash": "cbb57de6dc6270baa1a1efdff37be27d",
     "packages": [
         {
             "name": "api-platform/core",
@@ -6278,16 +6278,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.13.3",
+            "version": "v1.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "2597d0dda8042c43eed44a9cd07236b897e427d7"
+                "reference": "0170279814f86648c62aede39b100a343ea29962"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/2597d0dda8042c43eed44a9cd07236b897e427d7",
-                "reference": "2597d0dda8042c43eed44a9cd07236b897e427d7",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/0170279814f86648c62aede39b100a343ea29962",
+                "reference": "0170279814f86648c62aede39b100a343ea29962",
                 "shasum": ""
             },
             "require": {
@@ -6298,13 +6298,13 @@
                 "composer/composer": "^1.0.2|^2.0",
                 "symfony/dotenv": "^4.4|^5.0",
                 "symfony/filesystem": "^4.4|^5.0",
-                "symfony/phpunit-bridge": "^4.4|^5.0",
+                "symfony/phpunit-bridge": "^4.4.12|^5.0",
                 "symfony/process": "^3.4|^4.4|^5.0"
             },
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.13-dev"
+                    "dev-main": "1.17-dev"
                 },
                 "class": "Symfony\\Flex\\Flex"
             },
@@ -6326,7 +6326,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.13.3"
+                "source": "https://github.com/symfony/flex/tree/v1.17.2"
             },
             "funding": [
                 {
@@ -6342,7 +6342,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-19T07:19:15+00:00"
+            "time": "2021-10-21T08:39:19+00:00"
         },
         {
             "name": "symfony/form",


### PR DESCRIPTION
Please upgrade symfony/flex to 1.17+ on ALL your #Symfony applications ASAP. This version uses static files stored on Github instead of calling the http://flex.symfony.com server. The Flex server will go away at some point.

https://twitter.com/fabpot/status/1455191857659514889?s=20