### PR TITLE
Add new logic to reset database on run fpm prod image

### DIFF
--- a/backend/.docker/app-prod/php-fpm.sh
+++ b/backend/.docker/app-prod/php-fpm.sh
@@ -9,7 +9,7 @@
 
 console cache:warmup --no-interaction
 
-if [ "${APP_RESET_ON_BUILD:-}" = true ]; then
+if [ "${RESET_DATABASE:-}" = true ]; then
     console doctrine:database:drop --no-interaction --force
     console doctrine:database:create --no-interaction
 fi

--- a/backend/.docker/app-prod/php-fpm.sh
+++ b/backend/.docker/app-prod/php-fpm.sh
@@ -8,6 +8,12 @@
 # file that was distributed with this source code.
 
 console cache:warmup --no-interaction
+
+if [ "${APP_RESET_ON_BUILD:-}" = true ]; then
+    console doctrine:database:drop --no-interaction --force
+    console doctrine:database:create --no-interaction
+fi
+
 console doctrine:migrations:migrate --no-interaction --allow-no-migration
 
 php-fpm --allow-to-run-as-root


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Add new logic to reset database on build Dockerfile

<!-- Describe your Pull Request content here -->

In order to have the possibility to have environments that can be reseted, I have added a new variable that drops and creates the database in every build.

