### PR TITLE
Regenerate cache after reset database

### DIFF
--- a/backend/.docker/app-prod/php-fpm.sh
+++ b/backend/.docker/app-prod/php-fpm.sh
@@ -27,6 +27,10 @@ if [ "${RESET_DATABASE:-}" = true ]; then
 
     # Install production dependencies (due to our limitations in infrastructure)
     composer install --prefer-dist --no-progress --no-interaction --no-dev --classmap-authoritative
+
+    # Regenerate cache to avoid problems with dev or missing dependencies
+    rm -rf var/cache/*
+    console cache:warmup
 fi
 
 # Can be used on production environments to apply migrations to the database each time


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

We need to warmup cache again to avoid problems with dev dependencies, specially this error:

```
Unable to use the "Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor" class as the "phpdocumentor/reflection-docblock" package is not installed.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
