### PR TITLE
Bug: Social icons alignment when name is too long in participants list

### DIFF
--- a/frontend/components/App/Participants/styles.ts
+++ b/frontend/components/App/Participants/styles.ts
@@ -125,6 +125,7 @@ const ParticipantsDrawer = styled.div`
 
     .info {
       display: flex;
+      align-items: center;
       width: 100%;
       overflow: hidden;
 

--- a/frontend/components/App/Participants/styles.ts
+++ b/frontend/components/App/Participants/styles.ts
@@ -70,15 +70,15 @@ const ParticipantsDrawer = styled.div`
       }
     }
 
-    &.participant-list--speaking .participant .name {
-      max-width: ${rems(142)};
+    .participant .name {
+      display: inline-block;
     }
   }
 
   .participant {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 4fr minmax(70px, 1fr);
+    column-gap: ${space(2)};
     margin: ${space(2)} 0;
 
     &:last-child {
@@ -91,11 +91,10 @@ const ParticipantsDrawer = styled.div`
 
     .roles,
     .social {
-      min-width: ${rems(64)};
+      justify-self: end;
     }
 
     .name {
-      max-width: ${rems(160)};
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -126,8 +125,8 @@ const ParticipantsDrawer = styled.div`
 
     .info {
       display: flex;
-      align-items: center;
-      justify-content: flex-start;
+      width: 100%;
+      overflow: hidden;
 
       *:not(:last-child) {
         margin-right: ${space()};


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When the username is too long, the social icons are wrongly aligned.

<!-- Describe your Pull Request content here -->
+ Change flex to grid
+ Delete min and max widths to control it from parent (grid)
+ Change to inline block

Before:
![image](https://user-images.githubusercontent.com/13334047/141102065-1d46a6cc-cfae-447f-ad04-f4054bd577cc.png)

After:
![image](https://user-images.githubusercontent.com/13334047/141102523-2f286e19-c2d9-4fc0-90f5-d0a47dba2a0b.png)

