### PR TITLE
Fix error when granting permissions after joining

### DIFF
--- a/frontend/components/App/FishbowlPreJoin/index.tsx
+++ b/frontend/components/App/FishbowlPreJoin/index.tsx
@@ -88,7 +88,7 @@ const FishbowlPreJoin: React.FC = () => {
         const localTrack = localTracks.current[index];
 
         if (!localTrack.isAudioTrack()) {
-          const video = document.querySelector('video');
+          const video: HTMLVideoElement = document.querySelector('#prejoin');
 
           if (video) {
             localTrack.attach(video);
@@ -127,7 +127,7 @@ const FishbowlPreJoin: React.FC = () => {
           <Devices>
             <VideoContainer>
               {showPlaceholder && <VideoPlaceholder />}
-              <video autoPlay muted className="video" playsInline />
+              <video id="prejoin" autoPlay muted className="video" playsInline />
             </VideoContainer>
             <DevicesToolbar>
               <ButtonVideo


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Fix error when granting permissions after joining

This is probably a temporary fix, but it works. I just added an id to the video we really want to attach the stream.
We should find why it is not demounting.
