### PR TITLE
[Hotfix] Timer wrong display between hours

### DIFF
--- a/frontend/components/App/StatusBar/Counter.tsx
+++ b/frontend/components/App/StatusBar/Counter.tsx
@@ -99,6 +99,9 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
     const minutes: number = Math.floor((seconds / 60) % 60);
     const hours: number = getHours(seconds);
 
+    console.log(hours, minutes);
+    console.log(seconds);
+
     if (seconds === 0 && conferenceNotStarted) {
       timeLeftText = isModerator ? t('waitingHost') : t('waiting');
     } else if (seconds === 0 && timeStatus === ITimeStatus.TIME_UP) {
@@ -114,7 +117,7 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
       const time =
         hours > 0
           ? `${hours}${hoursText}:${minutes >= 10 ? minutes : `0${minutes}`}`
-          : Math.ceil(seconds / 60);
+          : Math.floor(seconds / 60);
       timeLeftText = t(conferenceNotStarted ? 'timeToStart' : 'timeLeft_other', {
         time: `${time}${minutesText}`
       });

--- a/frontend/components/App/StatusBar/Counter.tsx
+++ b/frontend/components/App/StatusBar/Counter.tsx
@@ -76,6 +76,16 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
     return () => clearInterval(intervalTimer);
   }, [fishbowlDate, completedTime, timeStatus]);
 
+  const getHours = (seconds: number): number => {
+    let hours = 0;
+    if (seconds === 3600) {
+      hours = Math.floor(seconds / 3600) - 1;
+    } else {
+      hours = Math.floor(seconds / 3600);
+    }
+    return hours;
+  };
+
   const rendererCountdown = (): string => {
     const conferenceNotStarted = conferenceStatus === IConferenceStatus?.NOT_STARTED;
     let timeLeftText;
@@ -86,8 +96,8 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
       clearInterval(intervalTimer);
     }
 
-    const minutes: number = Math.ceil(seconds / 60) % 60;
-    const hours: number = seconds === 3600 ? 0 : Math.floor(seconds / 3600);
+    const minutes: number = Math.floor((seconds / 60) % 60);
+    const hours: number = getHours(seconds);
 
     if (seconds === 0 && conferenceNotStarted) {
       timeLeftText = isModerator ? t('waitingHost') : t('waiting');

--- a/frontend/components/App/StatusBar/Counter.tsx
+++ b/frontend/components/App/StatusBar/Counter.tsx
@@ -76,15 +76,15 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
     return () => clearInterval(intervalTimer);
   }, [fishbowlDate, completedTime, timeStatus]);
 
-  const getHours = (seconds: number): number => {
-    let hours = 0;
-    if (seconds === 3600) {
-      hours = Math.floor(seconds / 3600) - 1;
-    } else {
-      hours = Math.floor(seconds / 3600);
-    }
-    return hours;
-  };
+  // const getHours = (seconds: number): number => {
+  //   let hours = 0;
+  //   if (seconds === 3599) {
+  //     hours = Math.floor(seconds / 3600) - 1;
+  //   } else {
+  //     hours = Math.floor(seconds / 3600);
+  //   }
+  //   return hours;
+  // };
 
   const rendererCountdown = (): string => {
     const conferenceNotStarted = conferenceStatus === IConferenceStatus?.NOT_STARTED;
@@ -97,7 +97,7 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
     }
 
     const minutes: number = Math.floor((seconds / 60) % 60);
-    const hours: number = getHours(seconds);
+    const hours: number = Math.floor(seconds / 3600);
 
     console.log(hours, minutes);
     console.log(seconds);
@@ -115,7 +115,7 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
       const hoursText = t('form:fishbowl.hours');
       const minutesText = t('form:fishbowl.minutes');
       const time =
-        hours > 0
+        hours > 0 && seconds >= 3600
           ? `${hours}${hoursText}:${minutes >= 10 ? minutes : `0${minutes}`}`
           : Math.floor(seconds / 60);
       timeLeftText = t(conferenceNotStarted ? 'timeToStart' : 'timeLeft_other', {

--- a/frontend/components/App/StatusBar/Counter.tsx
+++ b/frontend/components/App/StatusBar/Counter.tsx
@@ -76,16 +76,6 @@ export const Counter = ({ fishbowlData, timeStatus, conferenceStatus, isModerato
     return () => clearInterval(intervalTimer);
   }, [fishbowlDate, completedTime, timeStatus]);
 
-  // const getHours = (seconds: number): number => {
-  //   let hours = 0;
-  //   if (seconds === 3599) {
-  //     hours = Math.floor(seconds / 3600) - 1;
-  //   } else {
-  //     hours = Math.floor(seconds / 3600);
-  //   }
-  //   return hours;
-  // };
-
   const rendererCountdown = (): string => {
     const conferenceNotStarted = conferenceStatus === IConferenceStatus?.NOT_STARTED;
     let timeLeftText;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## The counter displays time wrongly

Jumps between hours was incorrect, for example from 3h to 2h it was like 3h:00m -> 2h60m 

Now its fixed to 3h:00m -> 2h59m and so on.

Also, last review showed 1h:00 -> 60m. Fixed to 1h -> 59m 

Also code has been simplified.