### PR TITLE
Change redirect when clicking CTA to Register instead of login

### DIFF
--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -190,7 +190,7 @@ const ProtectRoute = ({ children }) => {
     if (!loading && protectedRoutes) {
       const pathname = isAuthenticated
         ? router.query.redirect || ROUTE_HOME
-        : `${ROUTE_SIGN_IN}?redirect=${router.pathname}`;
+        : `${ROUTE_REGISTER}?redirect=${router.pathname}`;
       const route = pathname.toString();
       router.push(route, route, { locale: lang });
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Change the redirect

When an unregistered user clicked the main homes CTA it redirected them to login page instead of register. I changed the protected route default redirect to register.