### PR TITLE
Fix warning on import color.json

### DIFF
--- a/frontend/ui/settings.js
+++ b/frontend/ui/settings.js
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { colors } from '@/ui/design-tokens/color.json';
+import color from '@/ui/design-tokens/color.json';
 
 const BREAKPOINTS = {
   desktop: 1024,
@@ -23,7 +23,7 @@ const BREAKPOINTS = {
 
 const BORDER_RADIUS = '5px';
 
-const _getDesignToken = color => (colors[color] ? colors[color].value : '');
+const _getDesignToken = colorName => (color.colors[colorName] ? color.colors[colorName].value : '');
 
 // Colors
 const COLOR_NEUTRO_100 = _getDesignToken('neutral100');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

When running the app on local environment I keep getting this warning:

```
hot-dev-client.js?1600:88 ./ui/settings.js
Should not import the named export 'colors' (imported as 'colors') from default-exporting module (only default export is available soon)
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
