### PR TITLE
auth variable might be null

### DIFF
--- a/frontend/lib/jitsi-modules/Conference.js
+++ b/frontend/lib/jitsi-modules/Conference.js
@@ -230,7 +230,7 @@ const conferenceRepository = () => {
 
     connection = new JitsiMeetJS.JitsiConnection(
       null,
-      isUserModerator ? auth.token : null,
+      isUserModerator && auth ? auth.token : null,
       connectionOptions(roomName)
     );
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

There are cases where the auth variable might be null but you are still the admin. Most of this happens when you login on production and then try to create a fishbowl on staging.

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
