### PR TITLE
Hide devices list when clicking outside

### DIFF
--- a/frontend/components/App/ToolBar/index.tsx
+++ b/frontend/components/App/ToolBar/index.tsx
@@ -24,6 +24,7 @@ import ButtonVideo from '@/components/App/ButtonVideo';
 import ButtonConfig from '@/components/App/ButtonConfig';
 import { Container } from '@/components/App/ToolBar/styles';
 import { useDevices } from '@/contexts/DevicesContext';
+import useEventListener from '@/hooks/useEventListener';
 
 const ToolBar = () => {
   const [joined, setJoined] = useState(false);
@@ -58,11 +59,13 @@ const ToolBar = () => {
     tracksRepository.toggleVideoTrack();
   };
 
-  const handleParentClick = event => {
+  const handleOutsideClick = event => {
     if (event.target.id !== 'config-button') {
       configButtonRef.current.handleShowDevices(false);
     }
   };
+
+  useEventListener('click', handleOutsideClick);
 
   useEffect(() => {
     if (null !== audioOutputDevice) {
@@ -111,7 +114,7 @@ const ToolBar = () => {
   const joinLabel = joined ? t('leave') : !seatsAvailable ? t('full') : t('join');
 
   return (
-    <Container onClick={handleParentClick} className={isModerator ? 'moderator' : ''}>
+    <Container className={isModerator ? 'moderator' : ''}>
       <ButtonJoin joined={joined} join={joinSeat} leave={leaveSeat} disabled={isActionDisabled}>
         {joinLabel}
       </ButtonJoin>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Hidding the devices list when clicking outside. Just added an `eventListener`. 