### PR TITLE
Avoid failing E2E frontend tests on PRs opened from a fork repository

### DIFF
--- a/.github/workflows/frontend-test.yaml
+++ b/.github/workflows/frontend-test.yaml
@@ -84,8 +84,8 @@ jobs:
                 build: npm run build-e2e
                 start: npm run start-e2e
                 wait-on: 'http://localhost:3000'
-                parallel: true
-                record: true
+                parallel: ${{ github.ref == 'refs/heads/main' }}
+                record: ${{ github.ref == 'refs/heads/main' }}
                 working-directory: frontend
               env:
                 CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

When running a PR on a fork we can't run actions with secrets, so we won't report to cypress dashboard unless is a direct commit to main. Even with that limitation, cypress test can still run and generate coverage.

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
