### PR TITLE
Remove HSTS on localhost

### DIFF
--- a/backend/.docker/nginx-dev/default.conf.template
+++ b/backend/.docker/nginx-dev/default.conf.template
@@ -84,7 +84,6 @@ server {
     server_tokens off;
     http2_push_preload on;
 
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options nosniff always;
     add_header X-Frame-Options SAMEORIGIN always;
     add_header X-XSS-Protection "1; mode=block" always;

--- a/frontend/.docker/nginx-dev/default.conf.template
+++ b/frontend/.docker/nginx-dev/default.conf.template
@@ -75,7 +75,6 @@ server {
     server_tokens off;
     http2_push_preload on;
 
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options nosniff always;
     add_header X-Frame-Options SAMEORIGIN always;
     add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

There no need to enable that header on localhost. It makes horrible thing happen since it forbids the use of http for localhost.

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
