### PR TITLE
Renovate Bot should not sign DCO

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -39,4 +39,4 @@ jobs:
                   create-file-commit-message: 'Creating file for storing DCO Signatures'
                   signed-commit-message: '$contributorName has signed the DCO in #$pullRequestNo'
                   custom-allsigned-prcomment: '**DCO Assistant** All Contributors have signed the DCO. 📝 ✅ '
-                  allowlist: stooa-dev,weblate
+                  allowlist: stooa-dev,weblate,renovate


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Renovate bot is not able to sign dco because it is a bot. We should add him to the allowlist.

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
