### PR TITLE
Dipose track if video is not found

### DIFF
--- a/frontend/src/components/App/FishbowlPreJoin/index.tsx
+++ b/frontend/src/components/App/FishbowlPreJoin/index.tsx
@@ -101,6 +101,8 @@ const FishbowlPreJoin: React.FC = () => {
               .catch(error => {
                 console.log('[STOOA] Problem with auto play', error);
               });
+          } else {
+            disposeLocalTracks();
           }
         }
       }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

When you are on the PRE fishbowl, if you click fast enough on the button to enter, and don't give time to load the video. You end up in a situation where your camera will keep opened forever without an easy solution (only stops when refreshing or closing the chrome tab).

This PR fixes that by disposing local tracks if no video tag is found.

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
