### PR TITLE
Allow to execute Next.js outside Docker

### DIFF
--- a/.env
+++ b/.env
@@ -72,4 +72,4 @@ BACKEND=backend.meet.jitsi
 JICOFO=focus.meet.jitsi
 
 # NGINX
-NGINX_CUSTOM_JITSI_CORS_URL=https://localhost:8343
+NGINX_CUSTOM_JITSI_CORS_URL=*

--- a/backend/.env
+++ b/backend/.env
@@ -9,7 +9,7 @@ APP_ENV=dev
 APP_DEBUG=1
 APP_SECRET=f778485a199b7b12b46570ac380245d6
 APP_URL=https://localhost:8343
-CORS_ALLOW_ORIGIN=^https://localhost:8343$
+CORS_ALLOW_ORIGIN=^https?://localhost:(8343|3000)$
 
 DATABASE_URL=mysql://symfony:symfony@mysql:3306/symfony?serverVersion=5.7
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,8 +45,6 @@ services:
         build:
             context: frontend
             target: next-dev
-        ports:
-            - 3000:3000
         volumes:
             - ./frontend:/usr/app/:cached
             - /usr/app/node_modules/

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,7 +22,8 @@
     "sourceMap": true,
     "jsx": "preserve",
     "types": ["cypress", "@testing-library/cypress"],
-    "typeRoots": ["node_modules/@types/*", "*.d.ts", "src/types/*"]
+    "typeRoots": ["node_modules/@types/*", "*.d.ts", "src/types/*"],
+    "incremental": true
   },
   "exclude": ["node_modules"],
   "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"]

--- a/jitsi/.docker/nginx-dev/default.conf.template
+++ b/jitsi/.docker/nginx-dev/default.conf.template
@@ -14,7 +14,7 @@ server {
 server {
     listen 443 ssl http2 default_server;
 
-    client_max_body_size 0;
+    add_header Access-Control-Allow-Origin ${NGINX_CUSTOM_JITSI_CORS_URL};
 
     # Default
     location / {
@@ -66,8 +66,6 @@ server {
     server_tokens off;
     http2_push_preload on;
 
-    add_header Access-Control-Allow-Origin ${NGINX_CUSTOM_JITSI_CORS_URL};
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options nosniff always;
     add_header X-Frame-Options SAMEORIGIN always;
     add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

This PR allows to execute Next.js outside docker. You only need to enter the frontend folder and run:

```
cd frontend

nvm use # this will use node 17.4 (you need to do first nvm install 17.4)
npm ci # this will install the packages but  only the fixed versions of the lock file

npm run dev # for dev mode
npm run build-start # for prod mode
```

Make sure you have the docker started, like you did previously. The only difference is that you can access now `http://localhost:3000` (Yes, without https)

This does not affect at all the previous method of working with Stooa locally (https://localhost:8343) still works and it is not affected by this change. Instead we offer this new method.

It improves performance on dev mode, because does not run inside docker (specially painful when running MacOS)

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
