### PR TITLE
[Hotfix] - Host-now navigator arrow back

### DIFF
--- a/frontend/src/pages/fb/[fid].tsx
+++ b/frontend/src/pages/fb/[fid].tsx
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { useQuery } from '@apollo/client';
 import { useRouter } from 'next/router';
@@ -42,15 +42,7 @@ const Page = () => {
   const { fid } = router.query;
   const { loading, error, data } = useQuery(GET_FISHBOWL, { variables: { slug: fid } });
 
-  if (loading) return <Loader />;
-  if (error) return <Error message={error.message} />;
-
   const { bySlugQueryFishbowl: fb } = data;
-
-  if (!fb) {
-    router.push(ROUTE_NOT_FOUND, ROUTE_NOT_FOUND, { locale: lang });
-    return <Loader />;
-  }
 
   const handleJoinAsGuest = () => {
     setJoinAsGuest(true);
@@ -58,6 +50,27 @@ const Page = () => {
 
   const shoulPrintPreJoinPage: boolean = (joinAsGuest || isAuthenticated) && prejoin;
   const shoulPrintFishbowlPage: boolean = fishbowlReady && (isAuthenticated || isGuest);
+
+  useEffect(() => {
+    router.beforePopState(({ as }) => {
+      if (as !== router.asPath) {
+        console.log('Saura back lol');
+        console.log(as);
+      }
+      return true;
+    });
+
+    return () => {
+      router.beforePopState(() => true);
+    };
+  }, [router]);
+
+  if (loading) return <Loader />;
+  if (error) return <Error message={error.message} />;
+  if (!fb) {
+    router.push(ROUTE_NOT_FOUND, ROUTE_NOT_FOUND, { locale: lang });
+    return <Loader />;
+  }
 
   return shoulPrintPreJoinPage || shoulPrintFishbowlPage ? (
     <Layout data={fb} prejoin={shoulPrintPreJoinPage} title={fb.name}>

--- a/frontend/src/pages/fb/[fid].tsx
+++ b/frontend/src/pages/fb/[fid].tsx
@@ -52,7 +52,7 @@ const Page = () => {
   useEffect(() => {
     router.beforePopState(({ as }) => {
       if (as === '/fishbowl/host-now') {
-        router.push(ROUTE_HOME, ROUTE_HOME, { locale: lang });
+        router.replace(ROUTE_HOME, ROUTE_HOME, { locale: lang });
         return false;
       }
       return true;

--- a/frontend/src/pages/fb/[fid].tsx
+++ b/frontend/src/pages/fb/[fid].tsx
@@ -13,7 +13,7 @@ import { useQuery } from '@apollo/client';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 
-import { ROUTE_NOT_FOUND } from '@/app.config';
+import { ROUTE_HOME, ROUTE_NOT_FOUND } from '@/app.config';
 import { GET_FISHBOWL } from '@/lib/gql/Fishbowl';
 import withIsFishbowlEnded from '@/hocs/withIsFishbowlEnded';
 import { useStateValue } from '@/contexts/AppContext';
@@ -42,8 +42,6 @@ const Page = () => {
   const { fid } = router.query;
   const { loading, error, data } = useQuery(GET_FISHBOWL, { variables: { slug: fid } });
 
-  const { bySlugQueryFishbowl: fb } = data;
-
   const handleJoinAsGuest = () => {
     setJoinAsGuest(true);
   };
@@ -53,9 +51,9 @@ const Page = () => {
 
   useEffect(() => {
     router.beforePopState(({ as }) => {
-      if (as !== router.asPath) {
-        console.log('Saura back lol');
-        console.log(as);
+      if (as === '/fishbowl/host-now') {
+        router.push(ROUTE_HOME, ROUTE_HOME, { locale: lang });
+        return false;
       }
       return true;
     });
@@ -63,10 +61,12 @@ const Page = () => {
     return () => {
       router.beforePopState(() => true);
     };
-  }, [router]);
+  }, [router]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) return <Loader />;
   if (error) return <Error message={error.message} />;
+
+  const { bySlugQueryFishbowl: fb } = data;
   if (!fb) {
     router.push(ROUTE_NOT_FOUND, ROUTE_NOT_FOUND, { locale: lang });
     return <Loader />;

--- a/frontend/src/pages/fb/[fid].tsx
+++ b/frontend/src/pages/fb/[fid].tsx
@@ -42,7 +42,7 @@ const Page = () => {
   const { fid } = router.query;
   const { loading, error, data } = useQuery(GET_FISHBOWL, { variables: { slug: fid } });
 
-  const handleJoinAsGuest = () => {
+  const handleJoinAsGuest = (): void => {
     setJoinAsGuest(true);
   };
 

--- a/frontend/src/pages/fb/[fid].tsx
+++ b/frontend/src/pages/fb/[fid].tsx
@@ -51,7 +51,7 @@ const Page = () => {
 
   useEffect(() => {
     router.beforePopState(({ as }) => {
-      if (as === '/fishbowl/host-now') {
+      if (as === '/fishbowl/host-now' || as.includes('/fishbowl/detail')) {
         router.replace(ROUTE_HOME, ROUTE_HOME, { locale: lang });
         return false;
       }

--- a/frontend/src/pages/fb/[fid].tsx
+++ b/frontend/src/pages/fb/[fid].tsx
@@ -50,7 +50,7 @@ const Page = () => {
   const shoulPrintFishbowlPage: boolean = fishbowlReady && (isAuthenticated || isGuest);
 
   useEffect(() => {
-    router.beforePopState(({ as }) => {
+    router.beforePopState(({ as }): boolean => {
       if (as === '/fishbowl/host-now' || as.includes('/fishbowl/detail')) {
         router.replace(ROUTE_HOME, ROUTE_HOME, { locale: lang });
         return false;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Everytime a user landed to `host-now` a fishbowl was created. So if they clicked back a fishbowl was created.
I had to check when user clicks back if the route is fishbowl now to redirect them to home.
We also added the scheduled fishbowl that had a loop when going back.

Tested in
- [x] Chrome
- [x] Safari
- [x] Firefox