### PR TITLE
Fix duplicated camera when joining and leaving fast

### DIFF
--- a/frontend/src/components/App/ToolBar/index.tsx
+++ b/frontend/src/components/App/ToolBar/index.tsx
@@ -28,7 +28,7 @@ import useEventListener from '@/hooks/useEventListener';
 
 const ToolBar: React.FC = () => {
   const [joined, setJoined] = useState(false);
-  const [joinIsInActive, setJoinIsInactive] = useState(false);
+  const [joinIsInactive, setJoinIsInactive] = useState(false);
   const { data, isModerator, conferenceStatus, timeStatus, conferenceReady } = useStooa();
   const { videoDevice, audioInputDevice, audioOutputDevice } = useDevices();
   const seatsAvailable = useSeatsAvailable();
@@ -44,7 +44,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(true);
         setJoinIsInactive(false);
-      }, 800);
+      }, 500);
     }
   };
 
@@ -56,7 +56,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(false);
         setJoinIsInactive(false);
-      }, 800);
+      }, 500);
     }
   };
 
@@ -136,7 +136,7 @@ const ToolBar: React.FC = () => {
     conferenceStatus === IConferenceStatus.INTRODUCTION ||
     (timeStatus === ITimeStatus.TIME_UP && !isModerator && !joined) ||
     (!joined && !seatsAvailable) ||
-    joinIsInActive;
+    joinIsInactive;
 
   const isMuteDisabled =
     !conferenceReady ||

--- a/frontend/src/components/App/ToolBar/index.tsx
+++ b/frontend/src/components/App/ToolBar/index.tsx
@@ -36,7 +36,7 @@ const ToolBar: React.FC = () => {
 
   const configButtonRef = useRef(null);
 
-  const joinSeat = async(user: User) => {
+  const joinSeat = async (user: User) => {
     setJoinIsInactive(true);
     if (!joined) {
       await join(user);
@@ -44,11 +44,11 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(true);
         setJoinIsInactive(false);
-      }, 800)
+      }, 800);
     }
   };
 
-  const leaveSeat = async() => {
+  const leaveSeat = async () => {
     setJoinIsInactive(true);
     if (joined) {
       await leave();
@@ -56,7 +56,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(false);
         setJoinIsInactive(false);
-      }, 800)
+      }, 800);
     }
   };
 
@@ -135,7 +135,8 @@ const ToolBar: React.FC = () => {
     conferenceStatus === IConferenceStatus.NOT_STARTED ||
     conferenceStatus === IConferenceStatus.INTRODUCTION ||
     (timeStatus === ITimeStatus.TIME_UP && !isModerator && !joined) ||
-    (!joined && !seatsAvailable) || joinIsInActive;
+    (!joined && !seatsAvailable) ||
+    joinIsInActive;
 
   const isMuteDisabled =
     !conferenceReady ||

--- a/frontend/src/components/App/ToolBar/index.tsx
+++ b/frontend/src/components/App/ToolBar/index.tsx
@@ -44,7 +44,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(true);
         setJoinIsInactive(false);
-      }, 1000);
+      }, 1200);
     }
   };
 
@@ -56,7 +56,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(false);
         setJoinIsInactive(false);
-      }, 1000);
+      }, 1200);
     }
   };
 

--- a/frontend/src/components/App/ToolBar/index.tsx
+++ b/frontend/src/components/App/ToolBar/index.tsx
@@ -44,7 +44,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(true);
         setJoinIsInactive(false);
-      }, 800);
+      }, 1000);
     }
   };
 
@@ -56,7 +56,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(false);
         setJoinIsInactive(false);
-      }, 800);
+      }, 1000);
     }
   };
 

--- a/frontend/src/components/App/ToolBar/index.tsx
+++ b/frontend/src/components/App/ToolBar/index.tsx
@@ -44,7 +44,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(true);
         setJoinIsInactive(false);
-      }, 500);
+      }, 800);
     }
   };
 
@@ -56,7 +56,7 @@ const ToolBar: React.FC = () => {
       setTimeout(() => {
         setJoined(false);
         setJoinIsInactive(false);
-      }, 500);
+      }, 800);
     }
   };
 

--- a/frontend/src/components/App/ToolBar/index.tsx
+++ b/frontend/src/components/App/ToolBar/index.tsx
@@ -28,6 +28,7 @@ import useEventListener from '@/hooks/useEventListener';
 
 const ToolBar: React.FC = () => {
   const [joined, setJoined] = useState(false);
+  const [joinIsInActive, setJoinIsInactive] = useState(false);
   const { data, isModerator, conferenceStatus, timeStatus, conferenceReady } = useStooa();
   const { videoDevice, audioInputDevice, audioOutputDevice } = useDevices();
   const seatsAvailable = useSeatsAvailable();
@@ -35,17 +36,27 @@ const ToolBar: React.FC = () => {
 
   const configButtonRef = useRef(null);
 
-  const joinSeat = (user: User) => {
+  const joinSeat = async(user: User) => {
+    setJoinIsInactive(true);
     if (!joined) {
-      setJoined(true);
-      join(user);
+      await join(user);
+
+      setTimeout(() => {
+        setJoined(true);
+        setJoinIsInactive(false);
+      }, 800)
     }
   };
 
-  const leaveSeat = () => {
+  const leaveSeat = async() => {
+    setJoinIsInactive(true);
     if (joined) {
-      setJoined(false);
-      leave();
+      await leave();
+
+      setTimeout(() => {
+        setJoined(false);
+        setJoinIsInactive(false);
+      }, 800)
     }
   };
 
@@ -124,7 +135,7 @@ const ToolBar: React.FC = () => {
     conferenceStatus === IConferenceStatus.NOT_STARTED ||
     conferenceStatus === IConferenceStatus.INTRODUCTION ||
     (timeStatus === ITimeStatus.TIME_UP && !isModerator && !joined) ||
-    (!joined && !seatsAvailable);
+    (!joined && !seatsAvailable) || joinIsInActive;
 
   const isMuteDisabled =
     !conferenceReady ||

--- a/frontend/src/lib/jitsi.js
+++ b/frontend/src/lib/jitsi.js
@@ -22,7 +22,7 @@ const join = async user => {
   if (!localTracksCreated) {
     await localTracksRepository.createLocalTracks().then(tracks => {
       tracks.forEach(async track => {
-        tracksRepository.syncLocalStorageTrack(track, user);
+        await tracksRepository.syncLocalStorageTrack(track, user);
         conferenceRepository.addTrack(track);
       });
       localTracksCreated = true;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Sometimes, when joining and leaving fast with other users, the camera gets duplicated but only localy in the user's browser

Closes #444 .

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
