### PR TITLE
Hotfix - Login in two lines

### DIFF
--- a/frontend/src/components/Web/Header/index.tsx
+++ b/frontend/src/components/Web/Header/index.tsx
@@ -76,7 +76,13 @@ const Header: React.FC<Props> = ({ navigation = true }) => {
               )}
               {pathname !== ROUTE_REGISTER && (
                 <RedirectLink href={ROUTE_REGISTER} passHref>
-                  <Button size="medium" variant="secondary" as="a" data-testid="register">
+                  <Button
+                    className="never-full"
+                    size="medium"
+                    variant="secondary"
+                    as="a"
+                    data-testid="register"
+                  >
                     <span>{t('register')}</span>
                   </Button>
                 </RedirectLink>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix login in two lines when mobile in header.

### Before:
![image](https://user-images.githubusercontent.com/13334047/167126554-78502757-8c21-485d-9f27-912cec6a5bf7.png)


### After:
![image](https://user-images.githubusercontent.com/13334047/167126507-889582b4-9497-4fb4-8d0c-b1b71e44fb96.png)
