### PR TITLE
Reset token cookie before setting it

### DIFF
--- a/frontend/src/lib/auth/index.ts
+++ b/frontend/src/lib/auth/index.ts
@@ -27,11 +27,13 @@ const COOKIE_OPTIONS = { path: '/', domain: process.env.NEXT_PUBLIC_COOKIE_DOMAI
 const setToken = (token: string) => {
   const auth = new AuthToken(token);
   if (auth) {
+    cookie.remove(COOKIE_TOKEN, COOKIE_OPTIONS);
     cookie.set(COOKIE_TOKEN, token, { ...COOKIE_OPTIONS, expires: auth.decodedToken.exp });
   }
 };
 
 const setRefreshToken = (value: string) => {
+  cookie.remove(COOKIE_REFRESH, COOKIE_OPTIONS);
   cookie.set(COOKIE_REFRESH, value, { ...COOKIE_OPTIONS, expires: COOKIE_REFRESH_DAYS });
 };
 

--- a/frontend/src/lib/auth/index.ts
+++ b/frontend/src/lib/auth/index.ts
@@ -27,13 +27,13 @@ const COOKIE_OPTIONS = { path: '/', domain: process.env.NEXT_PUBLIC_COOKIE_DOMAI
 const setToken = (token: string) => {
   const auth = new AuthToken(token);
   if (auth) {
-    cookie.remove(COOKIE_TOKEN, COOKIE_OPTIONS);
+    cookie.remove(COOKIE_TOKEN);
     cookie.set(COOKIE_TOKEN, token, { ...COOKIE_OPTIONS, expires: auth.decodedToken.exp });
   }
 };
 
 const setRefreshToken = (value: string) => {
-  cookie.remove(COOKIE_REFRESH, COOKIE_OPTIONS);
+  cookie.remove(COOKIE_REFRESH);
   cookie.set(COOKIE_REFRESH, value, { ...COOKIE_OPTIONS, expires: COOKIE_REFRESH_DAYS });
 };
 

--- a/frontend/src/lib/auth/index.ts
+++ b/frontend/src/lib/auth/index.ts
@@ -27,13 +27,13 @@ const COOKIE_OPTIONS = { path: '/', domain: process.env.NEXT_PUBLIC_COOKIE_DOMAI
 const setToken = (token: string) => {
   const auth = new AuthToken(token);
   if (auth) {
-    cookie.remove(COOKIE_TOKEN);
+    cookie.remove(COOKIE_TOKEN, COOKIE_OPTIONS);
     cookie.set(COOKIE_TOKEN, token, { ...COOKIE_OPTIONS, expires: auth.decodedToken.exp });
   }
 };
 
 const setRefreshToken = (value: string) => {
-  cookie.remove(COOKIE_REFRESH);
+  cookie.remove(COOKIE_REFRESH, COOKIE_OPTIONS);
   cookie.set(COOKIE_REFRESH, value, { ...COOKIE_OPTIONS, expires: COOKIE_REFRESH_DAYS });
 };
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The [js-cookie](https://github.com/js-cookie/js-cookie) library does not distinguish between a domain and subdomain cookie. That's why we need to delete the cookie before setting it to avoid problems between production and staging environments.