### PR TITLE
Make slug not nullable

### DIFF
--- a/frontend/src/types/api-platform.ts
+++ b/frontend/src/types/api-platform.ts
@@ -7,51 +7,11 @@
  * file that was distributed with this source code.
  */
 
-import { User } from '@/types/user';
 import { Fishbowl as apiPlatformFishbowl } from './api-platform/interfaces/fishbowl';
-import { faker } from '@faker-js/faker';
 
-export interface Fishbowl extends Omit<apiPlatformFishbowl, 'startDateTimeTz' | 'endDateTimeTz'> {
+export interface Fishbowl
+  extends Omit<apiPlatformFishbowl, 'startDateTimeTz' | 'endDateTimeTz' | 'slug'> {
+  readonly slug: string;
   startDateTimeTz: string;
   endDateTimeTz: string;
 }
-
-type ParticipantConnection = {
-  edges?: ParticipantEdge[];
-  pageInfo: ParticipantPageInfo;
-  totalCount: number;
-};
-
-type ParticipantEdge = {
-  node?: Participant;
-  cursor: string;
-};
-
-type ParticipantPageInfo = {
-  endCursor?: string;
-  startCursor?: string;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-};
-
-type Participant = {
-  id: string;
-  user?: UserItem;
-  guest?: Guest;
-  lastPing: string;
-  fishbowl?: Fishbowl;
-};
-
-type Guest = {
-  id: string;
-};
-
-type UserItem = {
-  id: string;
-  name: string;
-  surnames: string;
-  email: string;
-  locale: string;
-  publicLinkedinProfile?: string;
-  publicTwitterProfile?: string;
-};

--- a/frontend/src/types/api-platform.ts
+++ b/frontend/src/types/api-platform.ts
@@ -10,7 +10,8 @@
 import { Fishbowl as apiPlatformFishbowl } from './api-platform/interfaces/fishbowl';
 
 export interface Fishbowl
-  extends Omit<apiPlatformFishbowl, 'startDateTimeTz' | 'endDateTimeTz' | 'slug'> {
+  extends Omit<apiPlatformFishbowl, '@id' | 'slug' | 'startDateTimeTz' | 'endDateTimeTz'> {
+  id?: string;
   readonly slug: string;
   startDateTimeTz: string;
   endDateTimeTz: string;

--- a/frontend/src/types/api-platform/interfaces/fishbowl.ts
+++ b/frontend/src/types/api-platform/interfaces/fishbowl.ts
@@ -8,7 +8,7 @@
  */
 
 export interface Fishbowl {
-  id?: string;
+  "@id"?: string;
   name?: string;
   description?: string;
   startDateTime: Date;
@@ -20,7 +20,6 @@ export interface Fishbowl {
   readonly slug?: string;
   readonly host?: string;
   readonly currentStatus?: string;
-  readonly participants?: string[];
   readonly startDateTimeTz?: Date;
   readonly endDateTimeTz?: Date;
   readonly durationFormatted?: string;

--- a/frontend/src/types/api-platform/interfaces/guest.ts
+++ b/frontend/src/types/api-platform/interfaces/guest.ts
@@ -8,6 +8,6 @@
  */
 
 export interface Guest {
-  '@id'?: string;
-  'name': string;
+  "@id"?: string;
+  name: string;
 }

--- a/frontend/src/types/api-platform/interfaces/participant.ts
+++ b/frontend/src/types/api-platform/interfaces/participant.ts
@@ -8,9 +8,9 @@
  */
 
 export interface Participant {
-  '@id'?: string;
-  readonly 'user'?: string;
-  readonly 'guest'?: string;
-  readonly 'lastPing'?: Date;
-  readonly 'fishbowl'?: string;
+  "@id"?: string;
+  readonly user?: string;
+  readonly guest?: string;
+  readonly lastPing?: Date;
+  readonly fishbowl?: string;
 }

--- a/frontend/src/types/api-platform/interfaces/user.ts
+++ b/frontend/src/types/api-platform/interfaces/user.ts
@@ -8,13 +8,13 @@
  */
 
 export interface User {
-  '@id'?: string;
-  'name': string;
-  'surnames': string;
-  'allowShareData'?: boolean;
-  'linkedinProfile'?: string;
-  'twitterProfile'?: string;
-  'plainPassword'?: string;
-  readonly 'email'?: string;
-  readonly 'locale'?: string;
+  "@id"?: string;
+  name: string;
+  surnames: string;
+  allowShareData?: boolean;
+  linkedinProfile?: string;
+  twitterProfile?: string;
+  plainPassword?: string;
+  readonly email?: string;
+  readonly locale?: string;
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

The slug is not really nullable. It is not nullable on the database, it can always be read (if you have the id of the fishbowl). Platform seems to think it is nullable from its auto generated types because it can't be written. Seems like a bug on their side.