### PR TITLE
Fix GID already exists error in macOS with m1 chip

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,8 +11,8 @@ FROM php:8.1-fpm-buster as base
 ARG UID=1000
 ARG GID=1000
 
-RUN usermod -u $UID www-data
-RUN groupmod -g $GID www-data
+RUN usermod --uid $UID www-data
+RUN groupmod --non-unique --gid $GID www-data
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -84,8 +84,8 @@ FROM nginx:1.21 as nginx
 ARG UID=1000
 ARG GID=1000
 
-RUN usermod -u $UID nginx
-RUN groupmod -g $GID nginx
+RUN usermod --uid $UID nginx
+RUN groupmod --non-unique --gid $GID nginx
 
 COPY --chown=$UID:$GID --from=fpm /usr/app/public /usr/app/public
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -255,6 +255,7 @@ services:
     # EXTRA
     mysql:
         image: mysql:5.7
+        platform: linux/amd64
         ports:
             - 8336:3306
         environment:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,8 +11,8 @@ FROM node:17.4 as base
 ARG UID=1000
 ARG GID=1000
 
-RUN usermod -u $UID node
-RUN groupmod -g $GID node
+RUN usermod --uid $UID node
+RUN groupmod --non-unique --gid $GID node
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -50,7 +50,7 @@ FROM nginx:1.21 as nginx
 ARG UID=1000
 ARG GID=1000
 
-RUN usermod -u $UID nginx
-RUN groupmod -g $GID nginx
+RUN usermod --uid $UID nginx
+RUN groupmod --non-unique --gid $GID nginx
 
 COPY .docker/nginx-prod/default.conf.template /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Add the --non-unique flag to groupmod commands to avoid GID already exists error for macOS with m1 chip.