### PR TITLE
Remove before unload to confirm to test better options

### DIFF
--- a/frontend/src/components/App/Fishbowl/index.tsx
+++ b/frontend/src/components/App/Fishbowl/index.tsx
@@ -82,19 +82,6 @@ const Fishbowl: FC = () => {
       category: 'FishbowlReactions',
       label: 'Connect'
     });
-
-    const closeTabFunction = (e: BeforeUnloadEvent) => {
-      if (isModerator && conferenceStatus === IConferenceStatus.RUNNING) {
-        e.preventDefault();
-        e.returnValue = '';
-      }
-    };
-
-    addEventListener('beforeunload', closeTabFunction);
-
-    return () => {
-      removeEventListener('beforeunload', closeTabFunction);
-    };
   }, []);
 
   return (


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
There is one before unload event that is breaking the app because it shuts the jitsi connection.